### PR TITLE
Fix abstract calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.0.4"
+version = "1.0.5"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Este PR arregla los trackeos para métodos que se ubicaban dentro de clases que heredan de otra.

Fixes:
- [x] StackOverflow
- [x] Abstract class/inheritor references
- [x] PsiMethodReferenceExpressions
- [x] Super methods not in project sources